### PR TITLE
Updated Makefile and README.md to clear Kedro pipeline for fresh run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint
+.PHONY: install lint clean-dry-run clean run run-data-processing run-feature-engineering local-db-start local-db-stop
 
 install:
 	pip install -r requirements.txt
@@ -6,22 +6,39 @@ install:
 lint:
 	pre-commit run --all-files
 
+clean-dry-run:
+	cd content-optimization && \
+		find data/02_intermediate -mindepth 1 -type d -print && \
+		find data/03_primary -mindepth 1 -type d -print && \
+		find data/04_feature -mindepth 1 -type d -print
+
+clean:
+	cd content-optimization && \
+		find data/02_intermediate -mindepth 1 -type d -exec rm -rf {} + && \
+		find data/03_primary -mindepth 1 -type d -exec rm -rf {} + && \
+		find data/04_feature -mindepth 1 -type d -exec rm -rf {} +
+
+run:
+	cd content-optimization && \
+		kedro run
+
+run-data-processing:
+	cd content-optimization && \
+		kedro run --pipeline=data_processing
+
+run-feature-engineering:
+	cd content-optimization && \
+		kedro run --pipeline=feature_engineering
+
 #############################
 # Commands to run docker
 # for local development
 #############################
 
-.PHONY: local-db-start
 local-db-start:
 	@docker-compose --file ./docker/Dockercompose.yaml --env-file ./docker/dockercompose.env.local up hh-mongo -d
 
-
-.PHONY: local-db-stop
 local-db-stop:
 	@docker-compose --file ./docker/Dockercompose.yaml --env-file ./docker/dockercompose.env.local down hh-mongo
 
-
-
-
-
-all: lint
+all: install lint clean-dry-run clean run run-data-processing run-feature-engineering local-db-start local-db-stop

--- a/README.md
+++ b/README.md
@@ -176,3 +176,28 @@ The [`lint.yml`](.github/workflows/lint.yml) is a GitHub workflow that kicks off
 
 > [!NOTE]
 > The `pre-commit` will run regardless if you forget to explicitly call it. Nonetheless, it is recommended to call it explicitly so you can make any necessary changes in advanced.
+
+## Running Kedro from Root Directory
+
+It will be very common for you to run the pipeline every time a new update or feature gets added. This will ensure that you are working with the latest intermediate and primary data at all times.
+
+It can then get quite cumbersome to manually delete every sub-directory containing the intermediate or primary data generated from the pipeline every time there is an update.
+
+Therefore, we have provided a simple `make` command to automatically remove all intemediate and primary data before re-running the latest Kedro pipeline:
+
+> [!TIP]
+> To ensure your data directories in your Kedro project are clean, run:
+> ```
+> make clean
+> ```
+> If you want to run Kedro from the root directory, you can run the following command:
+> ```
+> make run
+> ```
+> This will populate all the new intermediate and primary data in the data directories in your Kedro project.
+
+> [!CAUTION]
+> Before running `make clean`, you should review the folders that would be deleted by `make clean`. To do so, run:
+> ```
+> make clean-dry-run
+> ```


### PR DESCRIPTION
### Updated `Makefile`
- Added new `make` commands to run the Kedro pipeline from root 
- Added `make clean` command to clear the data directories to "restart" for a fresh run whenever pipeline updates
- Added `make clean-dry-run` to `stdout` all directories to be deleted in the terminal 

### Documentation
- Updated `README.md` on how to use new `make` commands