### PR TITLE
Integrated `make test` to test kedro pipeline from root

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,41 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-    -   id: check-added-large-files
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: requirements-txt-fixer
-    -   id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
 
-- repo: https://github.com/psf/black
-  rev: 24.4.2
-  hooks:
-  # Run black
-  - id: black
-  - id: black-jupyter
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      # Run black
+      - id: black
+      - id: black-jupyter
 
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-  # Run isort
-  - id: isort
-    args: [--profile=black]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      # Run isort
+      - id: isort
+        args: [--profile=black]
 
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.9
-  hooks:
-   # Run the linter
-   - id: ruff
-     args: ['--fix']
-     types_or: [ python, pyi, jupyter ]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.9
+    hooks:
+      # Run the linter
+      - id: ruff
+        args: ["--fix"]
+        types_or: [python, pyi, jupyter]
 
-- repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.8.5
-  hooks:
-   # Run isort on Jupyter notebooks
-   - id: nbqa-isort
-     additional_dependencies: [isort==5.13.2]
-     args: [--profile=black]
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.8.5
+    hooks:
+      # Run isort on Jupyter notebooks
+      - id: nbqa-isort
+        additional_dependencies: [isort==5.13.2]
+        args: [--profile=black]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Added [data directories](content-optimization/tests/data) for test datasets
 - Removed use of `alive_progress` because of incompatibility with `pytest`
 
+---
+
+- Added [`run_tests.py`](run_tests.py) to provide as an entry point for `make test`
+
 ## July 9, 2024 <a id="july-9-2024"></a>
 
 - Created [`clustering`](content-optimization/src/content_optimization/pipelines/clustering) pipeline
@@ -19,7 +23,7 @@
 
 ---
 
-- Added [`script.py`](script.py) to provide as an entry point for Makefile commands
+- Added [`script.py`](script.py) to provide as an entry point for `make clean`
   - This is an improvement over the previous release on [July 6, 2024](#july-6-2024) where it was not compatible with Windows OS
 
 ## July 6, 2024 <a id="july-6-2024"></a>

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint clean-dry-run clean run local-db-start local-db-stop
+.PHONY: install lint clean-dry-run clean run test local-db-start local-db-stop
 
 install:
 	pip install -r requirements.txt
@@ -11,10 +11,10 @@ lint:
 DIRS ?= data/02_intermediate data/03_primary data/04_feature data/05_model_input data/06_models data/07_model_output
 
 clean-dry-run:
-	@python script.py --dry-run --dir $(DIRS)
+	@python script.py --dry-run --dirs $(DIRS)
 
 clean:
-	@python script.py --dir $(DIRS)
+	@python script.py --dirs $(DIRS)
 
 
 PIPELINE ?=
@@ -27,6 +27,11 @@ run:
 		kedro run --pipeline=$(PIPELINE); \
 	fi
 
+
+test:
+	@python run_tests.py --files $(FILES) --functions $(FUNCTIONS)
+
+
 #############################
 # Commands to run docker
 # for local development
@@ -38,4 +43,4 @@ local-db-start:
 local-db-stop:
 	@docker-compose --file ./docker/Dockercompose.yaml --env-file ./docker/dockercompose.env.local down hh-mongo
 
-all: install lint clean-dry-run clean run local-db-start local-db-stop
+all: install lint clean-dry-run clean run test local-db-start local-db-stop

--- a/README.md
+++ b/README.md
@@ -239,3 +239,24 @@ For more control, you may specify the pipeline you want to run:
 ```
 make run PIPELINE=data_processing
 ```
+
+### Testing Kedro
+
+If you want to run tests for Kedro from the root directory, you can run the following command:
+
+```
+make test
+```
+
+For more control, kedro takes into two arguments for the `--files` and `--functions` flags:
+
+```
+make test FILES="tests/pipelines/data_processing/test_pipeline.py tests/pipelines/data_processing/test_nodes.py"
+```
+
+```
+make test FUNCTIONS="test_data_processing_pipeline test_project_path"
+```
+
+> [!TIP]
+> This will be increasingly helpful when the number of unit tests and/or integration tests starts to grow. Consult the [Makefile](Makefile) for more information.

--- a/content-optimization/pyproject.toml
+++ b/content-optimization/pyproject.toml
@@ -45,6 +45,9 @@ source_dir = "src"
 addopts = """
 --cov-report term-missing \
 --cov src/content_optimization -ra"""
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]
 
 [tool.coverage.report]
 fail_under = 0

--- a/content-optimization/tests/pipelines/data_processing/conftest.py
+++ b/content-optimization/tests/pipelines/data_processing/conftest.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+
 import pytest
 from kedro.config import OmegaConfigLoader
 from kedro.io import DataCatalog
 from kedro_datasets.partitions.partitioned_dataset import PartitionedDataset
+
+# Get the project root directory
+project_path = Path.cwd()
 
 
 @pytest.fixture
@@ -9,15 +14,29 @@ def datasets() -> dict:
     datasets = {
         "all_contents": PartitionedDataset(
             dataset="pandas.ExcelDataset",
-            path="tests/data/01_raw/all_contents",
+            path=(
+                project_path / "tests" / "data" / "01_raw" / "all_contents"
+            ).as_posix(),
         ),
         "all_contents_standardized": PartitionedDataset(
             dataset="pandas.ParquetDataset",
-            path="tests/data/02_intermediate/all_contents_standardized",
+            path=(
+                project_path
+                / "tests"
+                / "data"
+                / "02_intermediate"
+                / "all_contents_standardized"
+            ).as_posix(),
         ),
         "all_contents_extracted": PartitionedDataset(
             dataset="pandas.ParquetDataset",
-            path="tests/data/02_intermediate/all_contents_extracted",
+            path=(
+                project_path
+                / "tests"
+                / "data"
+                / "02_intermediate"
+                / "all_contents_extracted"
+            ).as_posix(),
         ),
     }
     return datasets

--- a/content-optimization/tests/pipelines/data_processing/test_nodes.py
+++ b/content-optimization/tests/pipelines/data_processing/test_nodes.py
@@ -17,6 +17,8 @@ from src.content_optimization.pipelines.data_processing.nodes import (
     standardize_columns,
 )
 
+pd.options.mode.chained_assignment = None
+
 
 def test_standardize_columns(catalog: DataCatalog, num_cols: int = 28):
     """

--- a/content-optimization/tests/pipelines/data_processing/test_pipeline.py
+++ b/content-optimization/tests/pipelines/data_processing/test_pipeline.py
@@ -10,12 +10,15 @@ https://docs.pytest.org/en/latest/getting-started.html
 
 import logging
 
+import pandas as pd
 from kedro.io import DataCatalog
 from kedro.runner import SequentialRunner
 from pytest import LogCaptureFixture
 from src.content_optimization.pipelines.data_processing import (
     create_pipeline as create_dp_pipeline,
 )
+
+pd.options.mode.chained_assignment = None
 
 
 def test_data_processing_pipeline(caplog: LogCaptureFixture, catalog: DataCatalog):

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,81 @@
+import argparse
+import os
+import sys
+from argparse import Namespace
+
+import pandas as pd
+import pytest
+
+
+def parse_arguments() -> Namespace:
+    """
+    A function that parses arguments for running pytest with specific options.
+
+    Returns:
+        Namespace: The parsed arguments as a Namespace object.
+    """
+    parser = argparse.ArgumentParser(description="run pytest with specified options")
+    parser.add_argument(
+        "-f", "--files", type=str, help="specific test files to run", nargs="*"
+    )
+    parser.add_argument(
+        "-k", "--functions", type=str, help="specific test functions to run", nargs="*"
+    )
+    return parser.parse_args()
+
+
+def run_tests(args: Namespace) -> int:
+    """
+    A function that runs tests with specified options using pytest.
+
+    Parameters:
+        args (Namespace): The namespace object containing parsed arguments.
+
+    Returns:
+        int: The exit status of the pytest execution.
+    """
+    # Disable SettingWithCopyWarning
+    pd.options.mode.chained_assignment = None
+
+    os.chdir("content-optimization")
+
+    # Default pytest arguments
+    pytest_args = ["-v"]
+
+    # Add specific files if provided
+    if args.files:
+        pytest_args.extend(args.files)
+
+    # Add specific functions if provided
+    if args.functions:
+        pytest_args.extend(["-k", " or ".join(args.functions)])
+
+    print(pytest_args)
+
+    return pytest.main(pytest_args)
+
+
+def main():
+    """
+    The main function that serves as the entry point. It parses command line arguments,
+    runs tests with the specified options, and exits the program. It expects the following
+    arguments:
+
+    - --files:
+        A list of file paths to run pytest on.
+    - --functions:
+        A list of test function names to run pytest on.
+
+    Example usage:
+        python run_tests.py --files tests/pipelines/data_processing/test_pipeline.py \
+            tests/pipelines/data_processing/test_nodes.py
+
+        python run_tests.py --functions test_data_processing_pipeline \
+            test_project_path
+    """
+    args = parse_arguments()
+    sys.exit(run_tests(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/script.py
+++ b/script.py
@@ -83,9 +83,9 @@ def clean(
 
 def main():
     """
-    Main function that serves as the entry point of the script.
+    The main function that serves as the entry point of the script. It parses command line arguments
+    and expects the following arguments:
 
-    This function parses command line arguments using the argparse module. It expects the following arguments:
     - --dirs:
         A list of directories to clean. The choices are:
             * "data/02_intermediate"


### PR DESCRIPTION
- Integrated `make test` to test kedro pipeline from root
- Created `run_tests.py` to provide an entry point for `make test` command
- Documented usage in `README.md` (refer for more information)
- Updated these feature in `CHANGELOG.md`

### To-do:
- Use Github Actions to trigger CI pipeline to ensure all kedro tests passes before pull requests can be merged
- Should be triggerred whenever `nodes.py`, `pipelines.py`, `test_nodes.py` or `test_pipeline.py` are in commit

@issacj-17 Seems like you haven't been able to find a promising use-case to integrate a CI pipeline using GitHub Actions. So, I'll be assigning this to-do to you. Do take inspiration from the current Github Actions workflows. You may consult @TsienJin on his implementation for his frontend linting as well. Hope you gain some learnings from this!