### PR TITLE
Updated mocker and mongoconnector

### DIFF
--- a/backend/app/app/interfaces/db_connector_types.py
+++ b/backend/app/app/interfaces/db_connector_types.py
@@ -149,10 +149,7 @@ class DbConnector(ABC):
     """
 
     @abstractmethod
-    async def create_optimise_job(
-        self,
-        article_id: str,
-    ) -> str:
+    async def create_optimise_job(self, article_id: str) -> str:
         """
         Method to mark standalone articles to be optimised as "individual" articles.
         :param article_id:
@@ -186,10 +183,11 @@ class DbConnector(ABC):
     """
 
     @abstractmethod
-    async def create_remove_record(self, article_id: str) -> str:
+    async def create_remove_record(self, article_id: str, remarks: str) -> str:
         """
         Method to remove an article based on it's own ID.
         :param article_id:
+        :param remarks:
         :return: {str} id of article removed
         """
         pass

--- a/backend/app/app/models/article.py
+++ b/backend/app/app/models/article.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import List
 
+from app.utils.db_connector.mongo_connector.beanie_documents import ArticleDocument
 from pydantic import BaseModel, Field
 
 
@@ -15,7 +16,7 @@ class ArticleMeta(BaseModel):
 
     status: str = Field(default="")
 
-    data_modified: str = Field(default="")
+    date_modified: str = Field(default="")
 
     # Article peripheral information
     keywords: List[str] = Field(default=[])
@@ -26,9 +27,44 @@ class ArticleMeta(BaseModel):
     engagement_rate: float = Field(default=-1.0)
     number_of_views: int = Field(default=-1)
 
+    @classmethod
+    def convert(cls, articleDoc: ArticleDocument):
+        return cls(
+            id=articleDoc.id,
+            title=articleDoc.title,
+            description=articleDoc.description,
+            pr_name=articleDoc.pr_name,
+            content_category=articleDoc.content_category,
+            url=articleDoc.url,
+            date_modified=articleDoc.date_modified,
+            keywords=articleDoc.keywords,
+            labels=articleDoc.labels,
+            cover_image_url=articleDoc.cover_image_url,
+            engagement_rate=articleDoc.engagement_rate,
+            number_of_views=articleDoc.number_of_views,
+        )
+
 
 class Article(ArticleMeta):
     content: str
+
+    @classmethod
+    def convert(cls, articleDoc: ArticleDocument):
+        return cls(
+            id=articleDoc.id,
+            title=articleDoc.title,
+            description=articleDoc.description,
+            pr_name=articleDoc.pr_name,
+            content_category=articleDoc.content_category,
+            url=articleDoc.url,
+            date_modified=articleDoc.date_modified,
+            keywords=articleDoc.keywords,
+            labels=articleDoc.labels,
+            cover_image_url=articleDoc.cover_image_url,
+            engagement_rate=articleDoc.engagement_rate,
+            number_of_views=articleDoc.number_of_views,
+            content=articleDoc.content,
+        )
 
 
 class ArticleStatus(Enum):

--- a/backend/app/app/models/article.py
+++ b/backend/app/app/models/article.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import List
 
-from app.utils.db_connector.mongo_connector.beanie_documents import ArticleDocument
 from pydantic import BaseModel, Field
 
 
@@ -27,44 +26,9 @@ class ArticleMeta(BaseModel):
     engagement_rate: float = Field(default=-1.0)
     number_of_views: int = Field(default=-1)
 
-    @classmethod
-    def convert(cls, articleDoc: ArticleDocument):
-        return cls(
-            id=articleDoc.id,
-            title=articleDoc.title,
-            description=articleDoc.description,
-            pr_name=articleDoc.pr_name,
-            content_category=articleDoc.content_category,
-            url=articleDoc.url,
-            date_modified=articleDoc.date_modified,
-            keywords=articleDoc.keywords,
-            labels=articleDoc.labels,
-            cover_image_url=articleDoc.cover_image_url,
-            engagement_rate=articleDoc.engagement_rate,
-            number_of_views=articleDoc.number_of_views,
-        )
-
 
 class Article(ArticleMeta):
     content: str
-
-    @classmethod
-    def convert(cls, articleDoc: ArticleDocument):
-        return cls(
-            id=articleDoc.id,
-            title=articleDoc.title,
-            description=articleDoc.description,
-            pr_name=articleDoc.pr_name,
-            content_category=articleDoc.content_category,
-            url=articleDoc.url,
-            date_modified=articleDoc.date_modified,
-            keywords=articleDoc.keywords,
-            labels=articleDoc.labels,
-            cover_image_url=articleDoc.cover_image_url,
-            engagement_rate=articleDoc.engagement_rate,
-            number_of_views=articleDoc.number_of_views,
-            content=articleDoc.content,
-        )
 
 
 class ArticleStatus(Enum):

--- a/backend/app/app/models/article.py
+++ b/backend/app/app/models/article.py
@@ -32,7 +32,7 @@ class Article(ArticleMeta):
 
 
 class ArticleStatus(Enum):
-    COMBINE = "Combined"
-    IGNORE = "Ignored"
-    OPTIMISE = "Optimise"
-    REMOVE = "Remove"
+    COMBINE: str = "Combined"
+    IGNORE: str = "Ignored"
+    OPTIMISE: str = "Optimise"
+    REMOVE: str = "Remove"

--- a/backend/app/app/models/generated_article.py
+++ b/backend/app/app/models/generated_article.py
@@ -14,7 +14,7 @@ class GeneratedArticle(BaseModel):
 
     status: str = Field(default="")
 
-    data_modified: str = Field(default="")
+    date_modified: str = Field(default="")
 
     # Article peripheral information
     keywords: List[str] = Field(default=[])

--- a/backend/app/app/models/job_optimise.py
+++ b/backend/app/app/models/job_optimise.py
@@ -1,10 +1,11 @@
-from typing import List, Optional
+from typing import Optional
 
 from app.models.article import Article
+from app.models.generated_article import GeneratedArticle
 from pydantic import BaseModel
 
 
 class JobOptimise(BaseModel):
     id: str
-    original_article: List[Article]
-    generated_article: Optional[Article]
+    original_article: Article
+    generated_article: Optional[GeneratedArticle]

--- a/backend/app/app/scripts/populate_mongo_mock/generators/mocker.py
+++ b/backend/app/app/scripts/populate_mongo_mock/generators/mocker.py
@@ -1,9 +1,10 @@
+import asyncio
 import datetime
 import random
 from typing import List
 
 from app.interfaces.db_connector_types import DbConnector
-from app.models.article import Article
+from app.models.article import Article, ArticleStatus
 from app.models.edge import Edge
 from app.scripts.populate_mongo_mock.generators.string_generator import random_str
 from bson import ObjectId
@@ -47,9 +48,16 @@ class Mocker:
         self.percent_processed = percent_processed
         self.percent_connection = percent_connection
 
+        self.pr_name = [random_str(random.randint(5, 20)).strip() for _ in range(5)]
+        self.labels = [random_str(random.randint(5, 10)).strip() for _ in range(10)]
+        self.keywords = [random_str(random.randint(5, 10)).strip() for _ in range(10)]
+        self.content_category = [
+            random_str(random.randint(3, 10)).strip() for _ in range(10)
+        ]
+
     def __create_article_ids(self) -> List[str]:
         num_articles = random.randint(
-            2, (self.max_articles_per_cluster - self.min_articles_per_cluster)
+            1, (self.max_articles_per_cluster - self.min_articles_per_cluster)
         )
         # return [random_id(32) for _ in range(num_articles)]
         return [str(ObjectId()) for _ in range(num_articles)]
@@ -66,62 +74,150 @@ class Mocker:
     """
     Method to generate the status of an article based on the number of articles in a cluster
 
-    If cluster size is greater than 1, the status is "Combined" as the articles should be cominbed
-    else the status is "Ignored" as default.
+    If cluster size is greater than 1, the article status can either be Combined, Removed, Ignored or Optimised.
+    However, in a cluster of size greater than 1, there must be at least 2 articles with the status of Combined.
+
+    Else if cluster size is 1, the article status can be any of the 3 statuses except Combined.
     """
+
+    def __generate_article_status(self, cluster_size: int) -> List[str]:
+
+        if cluster_size > 1:
+            statuses = [status.value for status in ArticleStatus]
+            statuses_list = [ArticleStatus.COMBINE.value for i in range(2)]
+
+            remaining_statuses = random.choices(statuses, k=cluster_size - 2)
+
+            statuses_list.extend(remaining_statuses)
+            random.shuffle(statuses_list)
+
+            return statuses_list
+        else:
+            statuses = [status.value for status in ArticleStatus]
+            statuses.remove(ArticleStatus.COMBINE.value)
+
+            return [random.choice(statuses)]
+
+    async def __create_combine_articles(
+        self, cluster_id: str, combine_ids: List[str]
+    ) -> None:
+        subgroup_num = 1
+
+        while len(combine_ids) > 1:
+            if (len(combine_ids) - 2) < 2:
+                group_size = len(combine_ids)
+            else:
+                group_size = random.randint(
+                    2, len(combine_ids) - 2
+                )  # Create subgroups of varying sizes, minimum 2
+
+            await self.conn.create_combine_job(
+                cluster_id,
+                f"Subgroup {subgroup_num}",
+                random_str(),
+                combine_ids[:group_size],
+            )
+
+            subgroup_num += 1
+            combine_ids = combine_ids[group_size:]
+
+    def __create_article(self, article_id: str, status: str) -> Article:
+
+        return Article(
+            id=article_id,
+            title=random_str(),
+            description=random_str(128),
+            pr_name=random.choice(self.pr_name),
+            content_category=random.choice(self.content_category),
+            url="url",
+            status=status,
+            date_modified=self._create_date(),
+            keywords=random.sample(
+                self.keywords, random.randint(0, int(len(self.keywords) / 2))
+            ),
+            labels=random.sample(
+                self.labels, random.randint(0, int(len(self.labels) / 2))
+            ),
+            cover_image_url="image_url",
+            engagement_rate=random.uniform(0, 1),
+            number_of_views=random.randint(100, 99999),
+            content=random_str(128),
+        )
+
+    def __create_edges(self, article_ids: List[str]) -> List[Edge]:
+        return [
+            Edge(start=e[0], end=e[1], weight=random.uniform(0.5, 1))
+            for e in [
+                random.sample(article_ids, 2)
+                for _ in range(int(self.percent_connection * (len(article_ids) ** 2)))
+            ]
+        ]
+
+    async def create_articles(self, article_ids: List[str]) -> List[Article]:
+        articles = []
+        self.remove_ids = []
+        self.ignore_ids = []
+        self.optimise_ids = []
+        self.combine_ids = []
+
+        if bool(random.getrandbits(1)):  # Randomly decide if cluster has been reviewed
+            article_statuses = self.__generate_article_status(len(article_ids))
+
+            for x in article_ids:
+                article_status = article_statuses.pop()
+
+                if article_status == ArticleStatus.REMOVE.value:
+                    self.remove_ids.append(x)
+                elif article_status == ArticleStatus.IGNORE.value:
+                    self.ignore_ids.append(x)
+                elif article_status == ArticleStatus.OPTIMISE.value:
+                    self.optimise_ids.append(x)
+                elif article_status == ArticleStatus.COMBINE.value:
+                    self.combine_ids.append(x)
+
+                articles.append(self.__create_article(x, article_status))
+
+        else:
+            for x in article_ids:
+                articles.append(self.__create_article(x, ""))
+
+        return articles
 
     async def mock(self) -> None:
 
         await self.conn.connect()
 
-        authors = [random_str(random.randint(5, 20)).strip() for _ in range(5)]
-        labels = [random_str(random.randint(5, 10)).strip() for _ in range(10)]
-        keywords = [random_str(random.randint(5, 10)).strip() for _ in range(10)]
-        pillar = [random_str(random.randint(3, 10)).strip() for _ in range(10)]
-
         for i in range(self.num_clusters):
 
             print(f"Mocking cluster {i+1}")
 
+            cluster_name = f"Cluster {random_str(5)}"
+
             article_ids = self.__create_article_ids()
 
-            articles = [
-                Article(
-                    id=x,
-                    title=random_str(),
-                    description=random_str(128),
-                    pr_name=random.choice(authors),
-                    content_category=random.choice(pillar),
-                    url="url",
-                    status="status",
-                    date_modified=self._create_date(),
-                    keywords=random.sample(
-                        keywords, random.randint(0, int(len(keywords) / 2))
-                    ),
-                    labels=random.sample(
-                        labels, random.randint(0, int(len(labels) / 2))
-                    ),
-                    cover_image_url="image_url",
-                    engagement_rate=random.uniform(0, 1),
-                    number_of_views=random.randint(100, 99999),
-                    content=random_str(128),
-                )
-                for x in article_ids
-            ]
+            articles = await self.create_articles(article_ids)
 
-            edges = [
-                Edge(start=e[0], end=e[1], weight=random.uniform(0.5, 1))
-                for e in [
-                    random.sample(article_ids, 2)
-                    for _ in range(
-                        int(self.percent_connection * (len(article_ids) ** 2))
-                    )
-                ]
-            ]
+            edges = self.__create_edges(article_ids) if len(article_ids) > 1 else []
 
             await self.conn.create_articles(articles)
-            await self.conn.create_cluster_from_articles(
-                "Cluster {random_str(5)}", article_ids
+            cluster_id = await self.conn.create_cluster_from_articles(
+                cluster_name, article_ids
             )
             if len(edges) > 0:
                 await self.conn.create_edges(edges)
+
+            if len(self.combine_ids) > 0:
+                await self.__create_combine_articles(cluster_id, self.combine_ids)
+
+            await asyncio.gather(
+                *(self.conn.create_ignore_record(i) for i in self.ignore_ids)
+            )
+            await asyncio.gather(
+                *(
+                    self.conn.create_remove_record(r, random_str())
+                    for r in self.remove_ids
+                )
+            )
+            await asyncio.gather(
+                *(self.conn.create_optimise_job(o) for o in self.optimise_ids)
+            )

--- a/backend/app/app/utils/db_connector/mongo_connector/beanie_documents.py
+++ b/backend/app/app/utils/db_connector/mongo_connector/beanie_documents.py
@@ -62,12 +62,12 @@ class JobCombineDocument(Document):
     sub_group_name: str
     remarks: str
     original_articles: List[Link[ArticleDocument]] = Field(default=[])
-    generated_article: Optional[Link[GeneratedArticleDocument]]
+    generated_article: Optional[Link[GeneratedArticleDocument]] = None
 
 
 class JobOptimiseDocument(Document):
     original_article: Link[ArticleDocument]
-    generated_article: Optional[Link[GeneratedArticleDocument]]
+    generated_article: Optional[Link[GeneratedArticleDocument]] = None
 
 
 class IgnoreDocument(Document):

--- a/backend/app/app/utils/db_connector/mongo_connector/mongo_connector.py
+++ b/backend/app/app/utils/db_connector/mongo_connector/mongo_connector.py
@@ -120,7 +120,7 @@ class MongoConnector(DbConnector):
     # endregion
 
     # region Helper functions
-    async def get_article_status(self, _id: str) -> str:
+    async def __get_article_status(self, _id: str) -> str:
         """
         Method to get a article status
         """
@@ -140,7 +140,7 @@ class MongoConnector(DbConnector):
     # endregion
 
     @staticmethod
-    async def convertToArticleMeta(articleDoc: ArticleDocument) -> ArticleMeta:
+    async def __convertToArticleMeta(articleDoc: ArticleDocument) -> ArticleMeta:
         return ArticleMeta(
             id=articleDoc.id,
             title=articleDoc.title,
@@ -157,7 +157,7 @@ class MongoConnector(DbConnector):
         )
 
     @staticmethod
-    async def convertToArticle(articleDoc: ArticleDocument) -> Article:
+    async def __convertToArticle(articleDoc: ArticleDocument) -> Article:
         return ArticleMeta(
             id=articleDoc.id,
             title=articleDoc.title,
@@ -174,11 +174,11 @@ class MongoConnector(DbConnector):
             content=articleDoc.content,
         )
 
-    async def convertToCluster(self, clusterDoc: ClusterDocument) -> Cluster:
+    async def __convertToCluster(self, clusterDoc: ClusterDocument) -> Cluster:
         return Cluster(
             id=str(clusterDoc.id),
             name=clusterDoc.name,
-            articles=[self.convertToArticleMeta(a) for a in clusterDoc.article_ids],
+            articles=[self.__convertToArticleMeta(a) for a in clusterDoc.article_ids],
             edges=self.get_edges([str(a.id) for a in clusterDoc.article_ids]),
         )
 
@@ -208,7 +208,7 @@ class MongoConnector(DbConnector):
         """
 
         return [
-            self.convertToCluster(c)
+            self.__convertToCluster(c)
             async for c in ClusterDocument.find_all(fetch_links=True)
         ]
 
@@ -220,7 +220,7 @@ class MongoConnector(DbConnector):
         """
         cluster = await ClusterDocument.get(cluster_id)
 
-        return self.convertToCluster(cluster)
+        return self.__convertToCluster(cluster)
 
     # endregion
 
@@ -259,7 +259,9 @@ class MongoConnector(DbConnector):
         This will not return article contents, in order to save on memory.
         :return: {List[ArticleMeta]}
         """
-        return [self.convertToArticleMeta(a) async for a in ArticleDocument.find_all()]
+        return [
+            self.__convertToArticleMeta(a) async for a in ArticleDocument.find_all()
+        ]
 
     async def get_articles(self, article_ids: List[str]) -> List[ArticleMeta]:
         """
@@ -268,7 +270,7 @@ class MongoConnector(DbConnector):
         :return: {List[Article]}
         """
         return [
-            self.convertToArticleMeta(a)
+            self.__convertToArticleMeta(a)
             async for a in ArticleDocument.find_many(article_ids)
         ]
 
@@ -363,7 +365,7 @@ class MongoConnector(DbConnector):
                 sub_group_name=j.sub_group_name,
                 remarks=j.remarks,
                 original_articles=[
-                    self.convertToArticle(a) for a in j.original_articles
+                    self.__convertToArticle(a) for a in j.original_articles
                 ],
             )
             for j in JobCombineDocument.find_all()
@@ -397,7 +399,7 @@ class MongoConnector(DbConnector):
         """
 
         return [
-            self.convertToArticleMeta(a) async for a in JobOptimiseDocument.find_all()
+            self.__convertToArticleMeta(a) async for a in JobOptimiseDocument.find_all()
         ]
 
     # endregion

--- a/frontend/app/src/app/components/article/article-card/article-card.component.html
+++ b/frontend/app/src/app/components/article/article-card/article-card.component.html
@@ -21,7 +21,7 @@ p-[1rem]
     </app-article-attribute>
 
     <app-article-attribute title="Reviewed">
-        {{article.data_modified | date}}
+        {{article.date_modified | date}}
     </app-article-attribute>
 
     <app-article-attribute title="Engagement">

--- a/frontend/app/src/app/components/article/article.component.html
+++ b/frontend/app/src/app/components/article/article.component.html
@@ -29,7 +29,7 @@ relative
         </div>
         <div class="grid grid-cols-2 gap-4 pl-4 flex-shrink-0">
             <app-article-attribute title="Contributor">{{ article.pr_name }}</app-article-attribute>
-            <app-article-attribute title="Reviewed">{{ article.data_modified | date }}</app-article-attribute>
+            <app-article-attribute title="Reviewed">{{ article.date_modified | date }}</app-article-attribute>
             <app-article-attribute title="Engagement Rate">{{ (article.engagement_rate*100).toFixed(1) }}%</app-article-attribute>
             <app-article-attribute title="Total Views">{{ article.number_of_views }}</app-article-attribute>
 

--- a/frontend/app/src/app/types/data/article.types.ts
+++ b/frontend/app/src/app/types/data/article.types.ts
@@ -14,7 +14,7 @@ export interface Article {
     pr_name: string,
     content_category: string,
     url: string,
-    data_modified: string,
+    date_modified: string,
     status: ArticleStatus,
     keywords: string[],
     cover_image_url: string,


### PR DESCRIPTION
- Db_connector_types
    - Added `remarks` parameter for creating a remove article

- Job_optimise
    - Updated typo in variable types

- Mocker
    - Added new methods to mock `Combine`, `Ignore`, `Optimise `and `Remove` article status
    - Note: 
        - A group/cluster can either be reviewed or not reviewed
        - If a group/cluster is not reviewed, all articles' status are blank
        - If a group/cluster is reviewed, all articles' status can be one of these status {`Combine`, `Ignore`, `Optimise`, `Remove`}
            - If cluster size is greater than 1, the article status can either be `Combine`, `Ignore`, `Optimise` or `Remove`.
                - However, in a cluster of size greater than 1, there must be at least 2 articles with the status of `Combine`.
            - Else if cluster size is 1, the article status can be any of the 3 statuses except `Combined`.

- Beanie_documents
    - `Optional` type must equate to a value otherwise it will throw an error when creating an instance of that document.

- mongo_connector
    - Added convert methods for `Article`, `ArticleMeta` and `Cluster` to reduce code duplication
    - Implemented abstract method

- Updated typo in variable: `data_modified` to `date_modified`

