### PR TITLE
Added new column for extracted_raw_html_tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## July 25, 2024 <a id="july-25-2024"></a>
+
+- Added column from `extracted_raw_html_tables` column
+  - Using raw html of tables for ingestion
+
 ## July 24, 2024 <a id="july-24-2024"></a>
 
 - Renamed column from `extracted_img_alt_text` to `extracted_images`.

--- a/content-optimization/README.md
+++ b/content-optimization/README.md
@@ -677,6 +677,19 @@ kedro run --nodes="extract_keywords_node"
 
   </details>
 
+- **`extracted_raw_html_tables`**
+
+  <details>
+
+  - Data Type: `list[string]`
+  - Description:
+    - A list of extracted tables in HTML extracted from the content body
+  - Null Values Allowed: Yes
+  - Primary Key: No
+  - Foreign Key: No
+
+  </details>
+
 - **`extracted_links`**
 
   <details>

--- a/content-optimization/src/content_optimization/pipelines/data_processing/extractor.py
+++ b/content-optimization/src/content_optimization/pipelines/data_processing/extractor.py
@@ -741,6 +741,19 @@ class HTMLExtractor:
 
         return tables if tables else None
 
+    def extract_raw_html_tables(self) -> Optional[list[str]]:
+        """
+        Extract all tables from the HTML content.
+
+        Returns:
+            list[str]: A list of tables in HTML format.
+        """
+        tables = []
+        for table in self.soup.find_all("table"):
+            tables.append(str(table))
+
+        return tables if tables else None
+
     def _process_table(self, table_html: PageElement) -> list[list[str]]:
         """
         Process a single HTML table and convert it to a list of lists.

--- a/content-optimization/src/content_optimization/pipelines/data_processing/nodes.py
+++ b/content-optimization/src/content_optimization/pipelines/data_processing/nodes.py
@@ -171,6 +171,7 @@ def extract_data(
         df["has_image"] = False
         df["related_sections"] = None
         df["extracted_tables"] = None
+        df["extracted_raw_html_tables"] = None
         df["extracted_links"] = None
         df["extracted_headers"] = None
         df["extracted_images"] = None
@@ -202,6 +203,7 @@ def extract_data(
             has_image = extractor.check_for_image()
             related_sections = extractor.extract_related_sections()
             extracted_tables = extractor.extract_tables()
+            extracted_raw_html_tables = extractor.extract_raw_html_tables()
             extracted_links = extractor.extract_links()
             extracted_headers = extractor.extract_headers()
             extracted_img_alt_text = extractor.extract_img_links_and_alt_text()
@@ -212,6 +214,7 @@ def extract_data(
             df.at[index, "has_image"] = has_image
             df.at[index, "related_sections"] = related_sections
             df.at[index, "extracted_tables"] = extracted_tables
+            df.at[index, "extracted_raw_html_tables"] = extracted_raw_html_tables
             df.at[index, "extracted_links"] = extracted_links
             df.at[index, "extracted_headers"] = extracted_headers
             df.at[index, "extracted_images"] = extracted_img_alt_text


### PR DESCRIPTION
As stated in trello, we will use the raw html of the table and ingest it directly.

Tests passed:

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/00e0de20-b2ec-4b29-95c0-6610f0572469">
